### PR TITLE
Use tempfile for cross-platform temporary directory creation

### DIFF
--- a/Snowpark_For_Python_ML.ipynb
+++ b/Snowpark_For_Python_ML.ipynb
@@ -305,14 +305,15 @@
    "source": [
     "import os\n",
     "from joblib import dump\n",
+    "import tempfile\n",
     "\n",
     "# Extract SKLearn object \n",
     "sk_model = model.to_sklearn()\n",
     "\n",
-    "model_output_dir = '/tmp'\n",
-    "model_file = os.path.join(model_output_dir, 'model.joblib')\n",
-    "dump(sk_model, model_file)\n",
-    "session.file.put(model_file,\"@dash_models\",overwrite=True)"
+    "with tempfile.TemporaryDirectory() as model_output_dir:\n",
+    "    model_file = os.path.join(model_output_dir, 'model.joblib')\n",
+    "    dump(sk_model, model_file)\n",
+    "    session.file.put(model_file, \"@dash_models\", overwrite=True)\n"
    ]
   },
   {

--- a/Snowpark_For_Python_ML.ipynb
+++ b/Snowpark_For_Python_ML.ipynb
@@ -313,7 +313,7 @@
     "with tempfile.TemporaryDirectory() as model_output_dir:\n",
     "    model_file = os.path.join(model_output_dir, 'model.joblib')\n",
     "    dump(sk_model, model_file)\n",
-    "    session.file.put(model_file, \"@dash_models\", overwrite=True)\n"
+    "    session.file.put(model_file, \"@dash_models\", overwrite=True)"
    ]
   },
   {


### PR DESCRIPTION
This code block fails for windows users, since `/tmp` doesn't exist. Use `tempfile` instead to create a temporary directory on any platform.