### PR TITLE
Restrict the sklearn version for vectorized UDF

### DIFF
--- a/Snowpark_For_Python_ML.ipynb
+++ b/Snowpark_For_Python_ML.ipynb
@@ -462,7 +462,7 @@
     "\n",
     "# Add trained model and Python packages from Snowflake Anaconda channel available on the server-side as UDF dependencies\n",
     "session.add_import('@dash_models/model.joblib.gz')\n",
-    "session.add_packages('pandas','joblib','scikit-learn','cachetools')\n",
+    "session.add_packages('pandas','joblib','scikit-learn==1.1.1','cachetools')\n",
     "\n",
     "@cachetools.cached(cache={})\n",
     "def load_model(filename):\n",


### PR DESCRIPTION
# Overview

This PR added a version restriction on scikit-learn for vectorized UDF, aligning its behavior with the scalar UDF which appeared prior to the vectorized UDF. This ensures the sklearn version remains unchanged for the UDF deployment.